### PR TITLE
Added onImport config key for compatibility with postcss-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,3 +147,20 @@ grunt.initConfig({
 	}
 });
 ```
+
+#### Misc
+
+Similarly to `postcss-import`, the list of imported files can be viewed by
+assigning a function to the `onImport` key among the options:
+
+```javascript
+less({
+  /* other Less.js options */
+  onImport: function(sources){
+    console.log(sources)
+  }
+})
+```
+
+The received sources will be an array of strings, containing the absolute path
+to the files, which were imported, including the source file.

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ assigning a function to the `onImport` key among the options:
 
 ```javascript
 less({
-  /* other Less.js options */
-  onImport: function(sources){
-    console.log(sources)
-  }
+	/* other Less.js options */
+	onImport: function(sources){
+		console.log(sources)
+	}
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,10 @@ var postcss = require('postcss')
 
 var render = require("./lib/render")(less.ParseTree, less.transformTree);
 
+function isFunction(f){
+  return typeof f === 'function';
+}
+
 function LessPlugin() {
 	var cacheInput;
 
@@ -273,7 +277,10 @@ function LessPlugin() {
 	    	}
 
 	        return new Promise(function (resolve, reject) {
-
+            var onImport = opts.onImport;
+            
+            delete opts.onImport
+            
 	        	cacheInput = cacheInput.toString();
 	        	if(!cacheInput) {
 	        		// TODO: explain the error
@@ -299,7 +306,11 @@ function LessPlugin() {
 						context = {};
 						// Convert Less AST to PostCSS AST
 						convertImports(imports.contents);
-
+            
+            if(isFunction(onImport)){
+              onImport(Object.keys(postCssInputs))
+            }
+            
 						processRules(css, evaldRoot.rules);
 						resolve();
 					}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var postcss = require('postcss')
 var render = require("./lib/render")(less.ParseTree, less.transformTree);
 
 function isFunction(f){
-  return typeof f === 'function';
+	return typeof f === 'function';
 }
 
 function LessPlugin() {
@@ -276,19 +276,19 @@ function LessPlugin() {
 		    	}
 	    	}
 
-	        return new Promise(function (resolve, reject) {
-            var onImport = opts.onImport;
-            
-            delete opts.onImport
-            
-	        	cacheInput = cacheInput.toString();
-	        	if(!cacheInput) {
-	        		// TODO: explain the error
-	        		reject(new CssSyntaxError(
-	        			"No input is present"
-	        		));
-	        	}
-	            render(cacheInput, opts, function(err, tree, evaldRoot, imports) {
+			return new Promise(function (resolve, reject) {
+				var onImport = opts.onImport;
+				
+				delete opts.onImport
+				
+				cacheInput = cacheInput.toString();
+				if(!cacheInput) {
+					// TODO: explain the error
+					reject(new CssSyntaxError(
+						"No input is present"
+					));
+				}
+				render(cacheInput, opts, function(err, tree, evaldRoot, imports) {
 					if(err) {
 						// Build PostCSS error
 						return reject(new CssSyntaxError(
@@ -306,11 +306,11 @@ function LessPlugin() {
 						context = {};
 						// Convert Less AST to PostCSS AST
 						convertImports(imports.contents);
-            
-            if(isFunction(onImport)){
-              onImport(Object.keys(postCssInputs))
-            }
-            
+						
+						if(isFunction(onImport)){
+							onImport(Object.keys(postCssInputs))
+						}
+						
 						processRules(css, evaldRoot.rules);
 						resolve();
 					}


### PR DESCRIPTION
Added a method for the plugin users to get the list of files imported by less. This feature can also be found in [postcss-import](https://github.com/postcss/postcss-import), but it only works for css files. This feature is great for people, who would like to develop some sort of watcher functionality around postcss.

Also, the key is removed from the options before passing it to the less parser.