### PR TITLE
Fixed onImport only being triggered once

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,10 +277,6 @@ function LessPlugin() {
 	    	}
 
 			return new Promise(function (resolve, reject) {
-				var onImport = opts.onImport;
-				
-				delete opts.onImport
-				
 				cacheInput = cacheInput.toString();
 				if(!cacheInput) {
 					// TODO: explain the error
@@ -307,8 +303,8 @@ function LessPlugin() {
 						// Convert Less AST to PostCSS AST
 						convertImports(imports.contents);
 						
-						if(isFunction(onImport)){
-							onImport(Object.keys(postCssInputs))
+						if(isFunction(opts.onImport)){
+							opts.onImport(Object.keys(postCssInputs))
 						}
 						
 						processRules(css, evaldRoot.rules);


### PR DESCRIPTION
I thought, that postcss would load the plugin multiple times, but it turned out, that if I delete the handler, then it will only run once. Fixed it. (gonna need this for the new watch feature for rollup-plugin-postcss)