### PR TITLE
Expose parser as a separate file

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,0 +1,3 @@
+var less = require('.');
+
+module.exports = less.parser;


### PR DESCRIPTION
This PR will allow you to reference parser as a string inside package.json when the module is used together with [browserify-postcss](https://www.npmjs.com/package/browserify-postcss).